### PR TITLE
Update top-pypi-packages filename

### DIFF
--- a/xdev/cli/docstr_stubgen.py
+++ b/xdev/cli/docstr_stubgen.py
@@ -487,7 +487,7 @@ def stdlib_names():
 @ub.memoize
 def common_module_names():
     """
-    fpath = ub.grabdata('https://raw.githubusercontent.com/hugovk/top-pypi-packages/main/top-pypi-packages-30-days.json', expires=86400)
+    fpath = ub.grabdata('https://raw.githubusercontent.com/hugovk/top-pypi-packages/main/top-pypi-packages.json', expires=86400)
     fpath = ub.Path(fpath)
     import json
     data = json.loads(fpath.read_text())


### PR DESCRIPTION
To stay within quota, it now has just under 30 days of data, so the filename has been updated. Both will be available for a while. See https://github.com/hugovk/top-pypi-packages/pull/46.